### PR TITLE
Add flag for outputting coverage to unit test target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: test-unit
 
 .PHONY: test-unit
 test-unit:
-	go test $(TESTS) -run 'Unit'
+	go test $(TESTS) -run 'Unit -coverprofile=coverage.out'
 
 .PHONY: lint
 lint: export GO111MODULE=off

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: test-unit
 
 .PHONY: test-unit
 test-unit:
-	go test $(TESTS) -run 'Unit -coverprofile=coverage.out'
+	go test $(TESTS) -run 'Unit' -coverprofile=coverage.out
 
 .PHONY: lint
 lint: export GO111MODULE=off


### PR DESCRIPTION
Output coverage when running unit tests using the Makefile by setting
the coverage flag. The coverage is stored and can be read by Sonar.