### PR TITLE
Update test names to match regex in Makefile

### DIFF
--- a/httpsession/httpsession_test.go
+++ b/httpsession/httpsession_test.go
@@ -9,9 +9,9 @@ import (
 
 // ---------------- Routes Through getSessionIDFromRequest() ----------------
 
-// TestGetSessionIDFromRequestInvalid - Verify that if a cookie doesn't exist by
+// TestUnitGetSessionIDFromRequestInvalid - Verify that if a cookie doesn't exist by
 // the name the config specifies, a blank session ID is returned
-func TestGetSessionIDFromRequestInvalid(t *testing.T) {
+func TestUnitGetSessionIDFromRequestInvalid(t *testing.T) {
 
 	Convey("Given the cookie by the name TEST doesn't exist", t, func() {
 
@@ -34,9 +34,9 @@ func TestGetSessionIDFromRequestInvalid(t *testing.T) {
 	})
 }
 
-// TestGetSessionIDFromRequestHappyPath - Verify that if a cookie does exist by
+// TestUnitGetSessionIDFromRequestHappyPath - Verify that if a cookie does exist by
 // the name the config specifies, a valid ID is returned
-func TestGetSessionIDFromRequestHappyPath(t *testing.T) {
+func TestUnitGetSessionIDFromRequestHappyPath(t *testing.T) {
 
 	Convey("Given the cookie by the name TEST exists", t, func() {
 

--- a/session/sessiondata_test.go
+++ b/session/sessiondata_test.go
@@ -1,7 +1,7 @@
 package session
 
 import (
-    "os"
+	"os"
 	"testing"
 	"time"
 
@@ -9,16 +9,16 @@ import (
 )
 
 func initConfig() {
-    os.Setenv("DEFAULT_SESSION_EXPIRATION", "5")
+	os.Setenv("DEFAULT_SESSION_EXPIRATION", "5")
 }
 
 func cleanupConfig() {
-    os.Unsetenv("DEFAULT_SESSION_EXPIRATION")
+	os.Unsetenv("DEFAULT_SESSION_EXPIRATION")
 }
 
-// TestGetAccessToken verifies that the session data access token is returned
+// TestUnitGetAccessToken verifies that the session data access token is returned
 // correctly
-func TestGetAccessToken(t *testing.T) {
+func TestUnitGetAccessToken(t *testing.T) {
 
 	Convey("Given I have session data with an access token", t, func() {
 
@@ -47,9 +47,9 @@ func TestGetAccessToken(t *testing.T) {
 	})
 }
 
-// TestGetRefreshToken verifies that the session data refresh token is returned
+// TestUnitGetRefreshToken verifies that the session data refresh token is returned
 // correctly
-func TestGetRefreshToken(t *testing.T) {
+func TestUnitGetRefreshToken(t *testing.T) {
 
 	Convey("Given I have session data with a refresh token", t, func() {
 
@@ -78,9 +78,9 @@ func TestGetRefreshToken(t *testing.T) {
 	})
 }
 
-// TestSetAccessToken verifies that the session data access token is stored
+// TestUnitSetAccessToken verifies that the session data access token is stored
 // correctly
-func TestSetAccessToken(t *testing.T) {
+func TestUnitSetAccessToken(t *testing.T) {
 
 	Convey("Given I have session data with an old access token", t, func() {
 
@@ -107,9 +107,9 @@ func TestSetAccessToken(t *testing.T) {
 	})
 }
 
-// TestSetRefreshToken verifies that the session data refresh token is stored
+// TestUnitSetRefreshToken verifies that the session data refresh token is stored
 // correctly
-func TestSetRefreshToken(t *testing.T) {
+func TestUnitSetRefreshToken(t *testing.T) {
 
 	Convey("Given I have session data with an old refresh token", t, func() {
 
@@ -136,9 +136,9 @@ func TestSetRefreshToken(t *testing.T) {
 	})
 }
 
-// TestGetOauth2TokenUserSignedIn verifies that an oauth2 token is returned when
+// TestUnitGetOauth2TokenUserSignedIn verifies that an oauth2 token is returned when
 // a user is signed in
-func TestGetOauth2TokenUserSignedIn(t *testing.T) {
+func TestUnitGetOauth2TokenUserSignedIn(t *testing.T) {
 
 	Convey("Given I have session data for a signed-in session", t, func() {
 		accessToken := "Foo"
@@ -175,9 +175,9 @@ func TestGetOauth2TokenUserSignedIn(t *testing.T) {
 	})
 }
 
-// TestGetOauth2TokenUserNotSignedIn verifies that nothing is returned when
+// TestUnitGetOauth2TokenNotUserSignedIn verifies that nothing is returned when
 // a user is signed in
-func TestGetOauth2TokenNotUserSignedIn(t *testing.T) {
+func TestUnitGetOauth2TokenNotUserSignedIn(t *testing.T) {
 
 	Convey("Given I have session data for a non-signed-in session", t, func() {
 
@@ -199,9 +199,9 @@ func TestGetOauth2TokenNotUserSignedIn(t *testing.T) {
 	})
 }
 
-// TestIsSignedInEmptySessionDataMap verifies that false is returned when
+// TestUnitIsSignedInEmptySessionDataMap verifies that false is returned when
 // checking if an empty session is signed in
-func TestIsSignedInEmptySessionDataMap(t *testing.T) {
+func TestUnitIsSignedInEmptySessionDataMap(t *testing.T) {
 
 	Convey("Given I have an empty session map", t, func() {
 
@@ -219,8 +219,8 @@ func TestIsSignedInEmptySessionDataMap(t *testing.T) {
 	})
 }
 
-// TestGetExpirationHappyPath verifies that expiration is returned successfully
-func TestGetExpirationHappyPath(t *testing.T) {
+// TestUnitGetExpirationHappyPath verifies that expiration is returned successfully
+func TestUnitGetExpirationHappyPath(t *testing.T) {
 
 	Convey("Given I have some session data with an 'expires_in' token", t, func() {
 
@@ -246,9 +246,9 @@ func TestGetExpirationHappyPath(t *testing.T) {
 	})
 }
 
-// TestGetExpirationNonePresent verifies that when expiration is not present on
+// TestUnitGetExpirationNonePresent verifies that when expiration is not present on
 // the session, 0 is returned
-func TestGetExpirationNonePresent(t *testing.T) {
+func TestUnitGetExpirationNonePresent(t *testing.T) {
 
 	Convey("Given I have some session data with no 'expires_in' token", t, func() {
 
@@ -270,9 +270,9 @@ func TestGetExpirationNonePresent(t *testing.T) {
 	})
 }
 
-// TestRefreshExpiration verifies that once refreshed, expiration is not nil
-func TestRefreshExpiration(t *testing.T) {
-    initConfig()
+// TestUnitRefreshExpiration verifies that once refreshed, expiration is not nil
+func TestUnitRefreshExpiration(t *testing.T) {
+	initConfig()
 
 	Convey("Given I have some session data", t, func() {
 
@@ -280,7 +280,7 @@ func TestRefreshExpiration(t *testing.T) {
 			"signin_info": map[string]interface{}{
 				"access_token": map[string]interface{}{},
 			},
-            "expires": 5,
+			"expires": 5,
 		}
 
 		Convey("When I call RefreshExpiration", func() {
@@ -294,5 +294,5 @@ func TestRefreshExpiration(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -2,7 +2,7 @@ package state
 
 import (
 	"errors"
-    "os"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -25,20 +25,20 @@ func getConfig() *config.Config {
 }
 
 func initConfig() {
-    os.Setenv("COOKIE_SECRET", "hello")
-    os.Setenv("COOKIE_NAME", "TEST")
+	os.Setenv("COOKIE_SECRET", "hello")
+	os.Setenv("COOKIE_NAME", "TEST")
 }
 
 func cleanupConfig() {
-    os.Unsetenv("COOKIE_SECRET")
-    os.Unsetenv("COOKIE_NAME")
+	os.Unsetenv("COOKIE_SECRET")
+	os.Unsetenv("COOKIE_NAME")
 }
 
 // ------------------- Routes Through SetSession() -------------------
 
-// TestSetSessionErrorOnSave - Verify error trapping if any errors are returned
+// TestUnitSetSessionErrorOnSave - Verify error trapping if any errors are returned
 // from redis
-func TestSetSessionErrorOnSave(t *testing.T) {
+func TestUnitSetSessionErrorOnSave(t *testing.T) {
 
 	Convey("Given a Redis error is thrown when saving session data", t, func() {
 
@@ -65,9 +65,9 @@ func TestSetSessionErrorOnSave(t *testing.T) {
 
 // ------------------- Routes Through GetSession() -------------------
 
-// TestGetSessionErrorPath - Verify error trapping if any errors are returned
+// TestUnitGetSessionErrorPath - Verify error trapping if any errors are returned
 // from redis
-func TestGetSessionErrorPath(t *testing.T) {
+func TestUnitGetSessionErrorPath(t *testing.T) {
 
 	Convey("Given a Redis error is thrown when retrieving session data", t, func() {
 
@@ -96,9 +96,9 @@ func TestGetSessionErrorPath(t *testing.T) {
 	})
 }
 
-// TestGetSessionHappyPath - Verify no errors are returned when following the
+// TestUnitGetSessionHappyPath - Verify no errors are returned when following the
 // GetSession 'happy path'
-func TestGetSessionHappyPath(t *testing.T) {
+func TestUnitGetSessionHappyPath(t *testing.T) {
 
 	Convey("Given no errors are thrown when retrieving session data", t, func() {
 
@@ -128,11 +128,11 @@ func TestGetSessionHappyPath(t *testing.T) {
 
 // ------------------- Routes Through Store() -------------------
 
-// TestStoreErrorInValidateSession - Verify session data is cleared if there's an
+// TestUnitStoreErrorInValidateSession - Verify session data is cleared if there's an
 // issue when validating the session data
-func TestStoreErrorInValidateSession(t *testing.T) {
+func TestUnitStoreErrorInValidateSession(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given I create a store with no data", t, func() {
 
@@ -150,14 +150,14 @@ func TestStoreErrorInValidateSession(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
-// TestStoreErrorInSetSession - Verify error trapping is enforced if there's an
+// TestUnitStoreErrorInSetSession - Verify error trapping is enforced if there's an
 // issue when saving the session data
-func TestStoreErrorInSetSession(t *testing.T) {
+func TestUnitStoreErrorInSetSession(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given I create a store with valid data but there's an error when saving the session",
 		t, func() {
@@ -193,14 +193,14 @@ func TestStoreErrorInSetSession(t *testing.T) {
 			})
 		})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
-// TestStoreHappyPath - Verify no errors are returned from Store if the happy
+// TestUnitStoreHappyPath - Verify no errors are returned from Store if the happy
 // path is followed
-func TestStoreHappyPath(t *testing.T) {
+func TestUnitStoreHappyPath(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given I create a store with valid data and I follow the 'happy path'",
 		t, func() {
@@ -235,16 +235,16 @@ func TestStoreHappyPath(t *testing.T) {
 			})
 		})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
 // ------------------- Routes Through validateExpiration() -------------------
 
-// TestValidateExpirationSessionHasExpired - Verify that when a session has
+// TestUnitValidateExpirationSessionHasExpired - Verify that when a session has
 // expired we throw an error
-func TestValidateExpirationSessionHasExpired(t *testing.T) {
+func TestUnitValidateExpirationSessionHasExpired(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given I have an expired session", t, func() {
 
@@ -267,14 +267,14 @@ func TestValidateExpirationSessionHasExpired(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
-// TestValidateExpirationNoExpirationSet - Verify that when 'expires' isn't set
+// TestUnitValidateExpirationNoExpirationSet - Verify that when 'expires' isn't set
 // on the store, it is set in validateExpiration
-func TestValidateExpirationNoExpirationSet(t *testing.T) {
+func TestUnitValidateExpirationNoExpirationSet(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given I have an session store with expires set to 0", t, func() {
 
@@ -303,16 +303,16 @@ func TestValidateExpirationNoExpirationSet(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
 // ------------------- Routes Through Delete() -------------------
 
-// TestDeleteErrorPath - Verify error trapping is enforced if there's an
+// TestUnitDeleteErrorPath - Verify error trapping is enforced if there's an
 // issue when deleting session data
-func TestDeleteErrorPath(t *testing.T) {
+func TestUnitDeleteErrorPath(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given a Redis error is thrown when deleting session data", t, func() {
 
@@ -338,14 +338,14 @@ func TestDeleteErrorPath(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
-// TestDeleteHappyPath - Verify no errors are returned when following the 'happy
+// TestUnitDeleteHappyPath - Verify no errors are returned when following the 'happy
 // path' whilst deleting session data
-func TestDeleteHappyPath(t *testing.T) {
+func TestUnitDeleteHappyPath(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given a the happy path is followed when deleting session data", t, func() {
 
@@ -370,16 +370,16 @@ func TestDeleteHappyPath(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
 // ------------------- Routes Through Clear() -------------------
 
-// TestClearErrorPath - Verify error trapping is enforced if there's an
+// TestUnitClearErrorPath - Verify error trapping is enforced if there's an
 // issue when clearing session data
-func TestClearErrorPath(t *testing.T) {
+func TestUnitClearErrorPath(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given a Redis error is thrown when deleting session data", t, func() {
 
@@ -406,13 +406,13 @@ func TestClearErrorPath(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
-// TestClearHappyPath - Verify no errors are returned from the Clear() happy path
-func TestClearHappyPath(t *testing.T) {
+// TestUnitClearHappyPath - Verify no errors are returned from the Clear() happy path
+func TestUnitClearHappyPath(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given no errors are thrown when deleting session data", t, func() {
 
@@ -442,16 +442,16 @@ func TestClearHappyPath(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
 // ---------------- Routes Through ValidateCookieSignature() ----------------
 
-// TestValidateCookieSignatureLengthInvalid - Verify that if the signature from
+// TestUnitValidateCookieSignatureLengthInvalid - Verify that if the signature from
 // the cookie is too short, an appropriate error is thrown
-func TestValidateCookieSignatureLengthInvalid(t *testing.T) {
+func TestUnitValidateCookieSignatureLengthInvalid(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given the cookie signature is less than the desired length", t, func() {
 
@@ -475,14 +475,14 @@ func TestValidateCookieSignatureLengthInvalid(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
-// TestValidateSessionIDHappyPath - Verify that no errors are thrown when
+// TestUnitValidateSessionIDHappyPath - Verify that no errors are thrown when
 // following the validate session ID 'happy path'
-func TestValidateSessionIDHappyPath(t *testing.T) {
+func TestUnitValidateSessionIDHappyPath(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given the session ID is valid", t, func() {
 
@@ -504,16 +504,16 @@ func TestValidateSessionIDHappyPath(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
 // ---------------- Routes Through decodeSession() ----------------
 
-// TestDecodeSessionBase64Invalid - Verify that if a cookie doesn't exist by
+// TestUnitDecodeSessionBase64Invalid - Verify that if a cookie doesn't exist by
 // the name the config specifies, a new blank cookie is returned
-func TestDecodeSessionBase64Invalid(t *testing.T) {
+func TestUnitDecodeSessionBase64Invalid(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given the session string isn't base64 encoded", t, func() {
 
@@ -533,14 +533,14 @@ func TestDecodeSessionBase64Invalid(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
-// TestDecodeSessionMessagepackInvalid - Verify that if a cookie doesn't exist by
+// TestUnitDecodeSessionMessagepackInvalid - Verify that if a cookie doesn't exist by
 // the name the config specifies, a new blank cookie is returned
-func TestDecodeSessionMessagepackInvalid(t *testing.T) {
+func TestUnitDecodeSessionMessagepackInvalid(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given the session string isn't messagepack encoded", t, func() {
 
@@ -562,16 +562,16 @@ func TestDecodeSessionMessagepackInvalid(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
 // ---------------- Routes Through Load() ----------------
 
-// TestLoadErrorInValidateSignature - Verify error trapping whilst validating a
+// TestUnitLoadErrorInValidateSignature - Verify error trapping whilst validating a
 // cookie signature
-func TestLoadErrorInValidateSignature(t *testing.T) {
+func TestUnitLoadErrorInValidateSignature(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given I have a session ID less than the desired length", t, func() {
 
@@ -599,14 +599,14 @@ func TestLoadErrorInValidateSignature(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
-// TestLoadErrorRetrievingSession - Verify error trapping whilst retrieving session
+// TestUnitLoadErrorRetrievingSession - Verify error trapping whilst retrieving session
 // data from Redis
-func TestLoadErrorRetrievingSession(t *testing.T) {
+func TestUnitLoadErrorRetrievingSession(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given I have a valid session ID", t, func() {
 
@@ -640,14 +640,14 @@ func TestLoadErrorRetrievingSession(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }
 
-// TestLoadErrorDecodingSession - Verify error trapping whilst decoding session
+// TestUnitLoadErrorDecodingSession - Verify error trapping whilst decoding session
 // data on load
-func TestLoadErrorDecodingSession(t *testing.T) {
+func TestUnitLoadErrorDecodingSession(t *testing.T) {
 
-    initConfig()
+	initConfig()
 
 	Convey("Given I have a valid session ID", t, func() {
 
@@ -680,5 +680,5 @@ func TestLoadErrorDecodingSession(t *testing.T) {
 		})
 	})
 
-    cleanupConfig()
+	cleanupConfig()
 }


### PR DESCRIPTION
Add "Unit" to tests to match regex filter in Makefile and update comments to match test names.

**Note:**
Some indentation formatting has been auto-applied by the Go formatter during a make test run.